### PR TITLE
Fix: Use model_name in graph and results

### DIFF
--- a/bracket-city-eval/bracket_city_graph.py
+++ b/bracket-city-eval/bracket_city_graph.py
@@ -42,6 +42,7 @@ def main():
         "game": game,
         "step_count": 0,
         "max_steps": args.num_steps, # Use parsed num_steps
+        "model_name": args.model_name, # Pass model_name to the graph
     }
 
     with get_openai_callback() as cb:
@@ -58,8 +59,8 @@ def main():
         result = {
             "game_completed": final_state["game_won"],
             "number_of_steps": final_state["step_count"],
-            "puzzle_date": date_str,
-            "model_name": "gpt-4o", # Replace with actual model name if available dynamically
+            "puzzle_date": args.date_str, # Use args.date_str
+            "model_name": args.model_name, # Use args.model_name
             "prompt_tokens": cb.prompt_tokens,
             "prompt_tokens_cached": cb.prompt_tokens_cached,
             "reasoning_token": cb.reasoning_tokens,

--- a/bracket-city-eval/graph.py
+++ b/bracket-city-eval/graph.py
@@ -12,11 +12,12 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-llm = ChatOpenAI(
-                model_name="openai/gpt-4.1-nano",
-                openai_api_base="https://openrouter.ai/api/v1",
-                openai_api_key=os.environ.get("OPENROUTER_API_KEY")
-            )
+# llm will be initialized dynamically in call_llm_node
+# llm = ChatOpenAI(
+#                 model_name="openai/gpt-4.1-nano", # This will be dynamic
+#                 openai_api_base="https://openrouter.ai/api/v1",
+#                 openai_api_key=os.environ.get("OPENROUTER_API_KEY")
+#             )
 
 class State(TypedDict):
     game: Game
@@ -26,6 +27,7 @@ class State(TypedDict):
     max_steps: int
     game_over: bool
     game_won: bool
+    model_name: str # Added model_name to state
 
 game_instructions = """
 You are an expert at the bracket city game tasked with solving a puzzle that is provided to you. 
@@ -76,6 +78,12 @@ def pre_hook_node(state: State):
     
 def call_llm_node(state: State):
     logging.debug(f"Calling LLM with message: {state['llm_message']}")
+    # Initialize LLM dynamically with model_name from state
+    llm = ChatOpenAI(
+        model_name=state["model_name"],
+        openai_api_base="https://openrouter.ai/api/v1", # Assuming this remains constant
+        openai_api_key=os.environ.get("OPENROUTER_API_KEY") # Assuming this remains constant
+    )
     response = llm.invoke([HumanMessage(state["llm_message"])])
     logging.debug(f"LLM Response: {response.content}")
     return {"llm_response": response.content}


### PR DESCRIPTION
- Pass model_name to the graph via initial_state in bracket_city_graph.py.
- Save the correct model_name and puzzle_date in the results JSON in bracket_city_graph.py.
- Add model_name to State TypedDict in graph.py.
- Dynamically instantiate ChatOpenAI with model_name from state in call_llm_node in graph.py.