### PR TITLE
fix: Correctly use llm-utils package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,13 @@ dependencies = [
     "python-dotenv>=1.1.0",
     "tenacity>=8.2.3", # Added tenacity for retry logic
     "wordle-python",
+    "llmutils",
 ]
 
 [tool.uv.sources]
 bracket-city-mcp = { git = "https://github.com/aplassard/bracket-city-mcp.git" }
 wordle-python = { git = "https://github.com/aplassard/wordle-python.git" }
+llmutils = { git = "https://github.com/aplassard/llm-utils.git" }
+
+[tool.setuptools.packages.find]
+include = ["wordle_agent*", "bracket_city_eval*"]

--- a/wordle_agent/graph.py
+++ b/wordle_agent/graph.py
@@ -4,7 +4,8 @@ from langgraph.graph import StateGraph, END
 import os
 import logging
 import re
-from bracket_city_eval.llm_utils import call_llm_with_retry, heal_llm_output
+from llmutils.llm_with_retry import call_llm_with_retry
+from llmutils.self_healing import heal_llm_output
 
 class State(TypedDict):
     game: wordle.Wordle
@@ -74,7 +75,11 @@ def take_turn_node(state: State):
     if not guess:
         logging.warning(f"Could not parse guess from LLM response: {state['llm_response']}. Attempting to heal.")
         try:
-            healed_response = heal_llm_output(state["llm_response"])
+            healed_response = heal_llm_output(
+                broken_text=state["llm_response"],
+                expected_format="guess: <five letter word>",
+                model_name=state["model_name"]
+            )
             guess = parse_guess(healed_response)
             if not guess:
                 logging.error(f"Failed to heal and parse guess from response: {healed_response}")


### PR DESCRIPTION
This commit corrects the usage of the  package by:
- Updating the  to correctly reference the  package.
- Updating the import statements in  to use the correct module paths.
- Correctly calling the  function with the expected arguments.